### PR TITLE
Fixed bug with 'UNIX' sockets on windows.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -47,7 +47,7 @@ function connect(){
 
     if(!client.port){
         client.log('Connecting client on Unix Socket :'.debug, client.path.variable);
-        if (process.platform ==='win32'){
+        if (process.platform ==='win32' && !client.path.startsWith('\\\\.\\pipe\\')){
             client.path = client.path.replace(/^\//, '');
             client.path = client.path.replace(/\//g, '-');
             client.path= '\\\\.\\pipe\\'+client.path;


### PR DESCRIPTION
Tried the windows 'UNIX' socket support today and found out that when reconecting on windows each reconnect prepends a new '\\\\.\\pipe\\'.

Have a nice day.
Greetings from Germany.