### PR TITLE
Using a client-specific flag to disconnect instead of using config.stopRetrying

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -16,7 +16,8 @@ function init(config,log){
         connect : connect,
         emit    : emit,
         log     : log,
-        retriesRemaining:config.maxRetries||0
+        retriesRemaining:config.maxRetries||0,
+        explicitlyDisconnected: false
     };
 
     new Pubsub(client);
@@ -143,7 +144,9 @@ function connect(){
         );
 
             if(
-                client.config.stopRetrying || client.retriesRemaining<1
+                client.config.stopRetrying ||
+                client.retriesRemaining<1 ||
+                client.explicitlyDisconnected
 
             ){
                 client.trigger('disconnect');

--- a/services/IPC.js
+++ b/services/IPC.js
@@ -92,7 +92,7 @@ function disconnect(id){
         return;
     }
 
-    this.of[id].config.stopRetrying=true;
+    this.of[id].explicitlyDisconnected=true;
 
     this.of[id].off('*');
     if(this.of[id].socket){


### PR DESCRIPTION
Consider the following code. Assume that that **unix_socket1** is up and running while **unix_socket2** is not.
```javascript
var ipc = require('node-ipc');

ipc.config.maxRetries = 3;
ipc.config.stopRetrying = false;

ipc.connectTo('unix_socket1', () => {
    ipc.of.unix_socket1.on('connect', () => {
		ipc.disconnect('unix_socket1');
		connectToSocket2();
    });
});

function connectToSocket2() {
	ipc.connectTo('unix_socket2', () => {
        ipc.of.unix_socket2.on('error', (error) => {
			// This will log 'true'
			console.log(ipc.of.unix_socket2.config.stopRetrying);
        });
    });
}
```
As **unix_socket2** will find the `stopRetrying` flag to be true, it will not attempt to retry to connect anymore, hence breaking the `maxRetries` policy set in the configurations.

The problem occurs because the a call to `disconnect` sets the `stopRetrying` flag of the client's configurations to true ([here](https://github.com/RIAEvangelist/node-ipc/blob/df0c6407c1c06cf3fe92bb0b26f7a448ba0263e1/services/IPC.js#L95)). The catch is that the `client.config` is actually the global `ipc.config` object, that's because when a new client is instantiated ([here](https://github.com/RIAEvangelist/node-ipc/blob/df0c6407c1c06cf3fe92bb0b26f7a448ba0263e1/services/IPC.js#L254)) it is passed `this.config` of the `ipc` object; and because it's an object it gets passed by reference not by copy , making the `client.config` point to the same thing as `ipc.config`.

So in the code example above when `disconnect` is called on **unix_socket1**, `ipc.config.stopRetrying` is set to true. And when the **unix_scoket2** is instantiated it gets the `stopRetrying` flag while it equals true, therefore it stops retrying when an error occurs even if retries are allowed.

The solution was to create another flag, called `explicitlyDisconnected`, that is unique to each client instance. This flag is then used instead of the `stopRetrying` flag.