### PR TITLE
Make sure production environments does not break due to event-pubsub updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "colors": "*",
-    "event-pubsub": "*",
+    "event-pubsub": "^2.0.0",
     "js-message": "*",
     "js-queue": "^0.1.2",
     "node-cmd": "*"


### PR DESCRIPTION
This was very, very hideous.

We had a line of code using ```ipc.off('eventName')```, which never spitted out any errors on our dev nor staging envs.

Three days ago, event-pubsub was updated, with better error handling. When I pushed to production, yesterday, things started hanging with no reason. No try-catch, inside an "await" call on a Promise. That was a very simple piece of code, no errors should be thrown in there.

The thing is, my `off` statement never worked, but it never complained as well. I pulled every single hair out of my head to find where the problem was and then figure out I should use ```ipc.off('eventName', '*')```.

I hope that makes sense. :)
