### PR TITLE
Add 'socket.disconnected' to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ or specifying everything UDP
 |----------|------|----------|
 |error|err obj|triggered when an error has occured|
 |connect||triggered when socket connected|
-|disconnect||triggered when socket disconnected|
+|disconnect||triggered by client when socket has disconnected from server|
+|socket.disconnected||socket destroyedSocketID||trigger by server when a client socket has disconnected|
 |destroy||triggered when socket has been totally destroyed, no further auto retries will happen and all references are gone.|
 |data|buffer|triggered when ipc.config.rawBuffer is true and a message is received.|
 |***your event type***|***your event data***|triggered when a JSON message is received. The event name will be the type string from your message and the param will be the data object from your message eg : ` { type:'myEvent',data:{a:1}} ` |
@@ -519,6 +520,12 @@ The server is the process keeping a socket for IPC open. Multiple sockets can co
                     );
                 }
             );
+			ipc.server.on(
+				'socket.disconnected',
+				function(socket, destroyedSocketID) {
+					ipc.log('client ' + destroyedSocketID + ' has disconnected!');
+				}
+			);
         }
     );
 

--- a/README.md
+++ b/README.md
@@ -453,8 +453,7 @@ or specifying everything UDP
 |----------|------|----------|
 |error|err obj|triggered when an error has occured|
 |connect||triggered when socket connected|
-|disconnect||triggered on client when socket disconnected|
-|socket.disconnect||triggered on server when a client socket disconnected| 
+|disconnect||triggered when socket disconnected|
 |destroy||triggered when socket has been totally destroyed, no further auto retries will happen and all references are gone.|
 |data|buffer|triggered when ipc.config.rawBuffer is true and a message is received.|
 |***your event type***|***your event data***|triggered when a JSON message is received. The event name will be the type string from your message and the param will be the data object from your message eg : ` { type:'myEvent',data:{a:1}} ` |
@@ -520,12 +519,6 @@ The server is the process keeping a socket for IPC open. Multiple sockets can co
                     );
                 }
             );
-			ipc.server.on(
-				'socket.disconnect',
-				function(socket, socketID) {
-					ipc.log('client ' + socketID + ' disconnected from me!')
-				}
-			);
         }
     );
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ or specifying everything UDP
 |error|err obj|triggered when an error has occured|
 |connect||triggered when socket connected|
 |disconnect||triggered by client when socket has disconnected from server|
-|socket.disconnected||socket destroyedSocketID||trigger by server when a client socket has disconnected|
+|socket.disconnected|socket destroyedSocketID|triggered by server when a client socket has disconnected|
 |destroy||triggered when socket has been totally destroyed, no further auto retries will happen and all references are gone.|
 |data|buffer|triggered when ipc.config.rawBuffer is true and a message is received.|
 |***your event type***|***your event data***|triggered when a JSON message is received. The event name will be the type string from your message and the param will be the data object from your message eg : ` { type:'myEvent',data:{a:1}} ` |

--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ or specifying everything UDP
 |----------|------|----------|
 |error|err obj|triggered when an error has occured|
 |connect||triggered when socket connected|
-|disconnect||triggered when socket disconnected|
+|disconnect||triggered on client when socket disconnected|
+|socket.disconnect||triggered on server when a client socket disconnected| 
 |destroy||triggered when socket has been totally destroyed, no further auto retries will happen and all references are gone.|
 |data|buffer|triggered when ipc.config.rawBuffer is true and a message is received.|
 |***your event type***|***your event data***|triggered when a JSON message is received. The event name will be the type string from your message and the param will be the data object from your message eg : ` { type:'myEvent',data:{a:1}} ` |
@@ -519,6 +520,12 @@ The server is the process keeping a socket for IPC open. Multiple sockets can co
                     );
                 }
             );
+			ipc.server.on(
+				'socket.disconnect',
+				function(socket, socketID) {
+					ipc.log('client ' + socketID + ' disconnected from me!')
+				}
+			);
         }
     );
 


### PR DESCRIPTION
I've added the event to the docs, however I think there may be a bug with the destroyedSocketID - it always shows up as false. I haven't really looked into it though.