### PR TITLE
Pr for server -> client connection

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -149,8 +149,8 @@ function connect(){
         'close',
         function connectionClosed(){
             client.log('connection closed' ,client.id , client.path,
-            client.retriesRemaining, 'tries remaining of', client.config.maxRetries
-        );
+                client.retriesRemaining, 'tries remaining of', client.config.maxRetries
+            );
 
             if(
                 client.config.stopRetrying ||
@@ -190,8 +190,8 @@ function connect(){
             client.log('## received events ##');
             if(client.config.rawBuffer){
                 client.publish(
-                   'data',
-                   new Buffer(data,client.config.encoding)
+                    'data',
+                    new Buffer(data,client.config.encoding)
                 );
                 if(!client.config.sync){
                     return;
@@ -222,16 +222,18 @@ function connect(){
 
                 if (message.type === '__identify') {
                     client.emit('__identify', {
-                        id: client.config.id
-                        //path: client.path
+                        id: client.config.id,
+
+                        // TODO: This can't be right....
+                        path: client.config.socketRoot + client.config.appspace + client.config.id
                     });
                     continue;
                 }
 
                 client.log('detected event', message.type, message.data);
                 client.publish(
-                   message.type,
-                   message.data
+                    message.type,
+                    message.data
                 );
             }
 

--- a/dao/client.js
+++ b/dao/client.js
@@ -222,8 +222,8 @@ function connect(){
 
                 if (message.type === '__identify') {
                     client.emit('__identify', {
-                        id: client.id,
-                        path: client.path
+                        id: client.config.id
+                        //path: client.path
                     });
                     continue;
                 }

--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -248,12 +248,13 @@ function serverCreated(socket) {
         );
     } else {
         this.on('__identify', function(clientDetails) {
-            var id = clientDetails.id,
-                clientConfig = Object.assign(this.config, {id: clientDetails.id, path: clientDetails.path});
+            let id = clientDetails.id,
+                path = clientDetails.path,
+                clientConfig = Object.assign(this.config, {id: id, path: path});
 
             this.of[id] = new Client(clientConfig, this.log, socket);
             this.of[id].id = id;
-            this.of[id].path = clientConfig.path;
+            this.of[id].path = path;
 
             this.of[id].on('disconnect', function() {
                 delete this.of[id];

--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -248,11 +248,12 @@ function serverCreated(socket) {
         );
     } else {
         this.on('__identify', function(clientDetails) {
-            var id = clientDetails.id;
+            var id = clientDetails.id,
+                clientConfig = Object.assign(this.config, {id: clientDetails.id, path: clientDetails.path});
 
-            this.of[id] = new Client(this.config, this.log, socket);
+            this.of[id] = new Client(clientConfig, this.log, socket);
             this.of[id].id = id;
-            this.of[id].path = clientDetails.path;
+            this.of[id].path = clientConfig.path;
 
             this.of[id].on('disconnect', function() {
                 delete this.of[id];

--- a/entities/Defaults.js
+++ b/entities/Defaults.js
@@ -108,6 +108,11 @@ class Defaults{
                     enumerable:true,
                     writable:true,
                     value:false
+                },
+                noHandshake     : {
+                    enumerable:true,
+                    writable:true,
+                    value:false
                 }
             }
         );


### PR DESCRIPTION
Hi 

This is my first github + public PR, so please don't shoot me :) 

But anyway, as mentioned over here -> 
https://github.com/RIAEvangelist/node-ipc/issues/92

I created a little pull-request, with some code to enable easier server -> client messaging..

In this case, when the server gets a new connection, a '__identify' event is send in which the child responses with {id: id, path: path}.. 

There doesn't seem to be another 100% save way to detect what/who is on the other side of a socket by design.
http://unix.stackexchange.com/questions/16300/whos-got-the-other-end-of-this-unix-socketpair.

A `new Client(this.config, this.log, socket)` instance is added to `ipc.server.of[clientID]`;

So you can just do `ipc.server.of[clientID].emit()` etc.

Also `ipc.server.of[clientID].id` and `ipc.server.of[clientID].path` is set.

The feature can be disabled by settings `ipc.config.noHandshake = true`;

Just let me know if this is something you would like to implement, otherwise I will go back to the server -> server design for my own project.. :)

Thanks 


p.s. a second option that would be a lot handier, but also a bit more dirty, is to do the __identify call and than just apply the returned id+path to the socket object. So you can reference it from everywhere  

`socket.id
  socket.path
`