### PR TITLE
Add handshake to client -> server

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -13,7 +13,7 @@ if(process.version[1]>4){
 }
 
 class Client extends Events{
-    constructor(config,log){
+    constructor(config,log,socket){
         super();
         Object.assign(
             this,
@@ -21,7 +21,7 @@ class Client extends Events{
                 Client  : Client,
                 config  : config,
                 queue   : new Queue,
-                socket  : false,
+                socket  : socket||false,
                 connect : connect,
                 emit    : emit,
                 log     : log,
@@ -29,6 +29,9 @@ class Client extends Events{
                 explicitlyDisconnected: false
             }
         );
+
+        if (this.config.requiresHandshake)
+            this.on('__hs', onHandshake.bind(this));
     }
 }
 
@@ -67,6 +70,11 @@ function connect(){
     client.log('requested connection to ', client.id, client.path);
     if(!this.path){
         client.log('\n\n######\nerror: ', client.id ,' client has not specified socket path it wishes to connect to.');
+        return;
+    }
+
+    if (client.socket !== false) {
+        client.log('Connection already set');
         return;
     }
 
@@ -136,11 +144,7 @@ function connect(){
 
     client.socket.on(
         'connect',
-        function connectionMade(){
-            client.publish('connect');
-            client.retriesRemaining=client.config.maxRetries;
-            client.log('retrying reset');
-        }
+        () => !this.config.requiresHandshake && onConnectionMade.call(this)
     );
 
     client.socket.on(
@@ -218,16 +222,6 @@ function connect(){
                 let message=new Message;
                 message.load(events[i]);
 
-                if (message.type === '__identify') {
-                    client.emit('__identify', {
-                        id: client.config.id,
-
-                        // TODO: This can't be right....
-                        path: client.config.socketRoot + client.config.appspace + client.config.id
-                    });
-                    continue;
-                }
-
                 client.log('detected event', message.type, message.data);
                 client.publish(
                    message.type,
@@ -242,6 +236,23 @@ function connect(){
             client.queue.next();
         }
     );
+}
+
+function onConnectionMade(){
+    this.publish('connect');
+    this.retriesRemaining=this.config.maxRetries;
+    this.log('retrying reset');
+}
+
+function onHandshake(status) {
+    if (status.complete)
+        onConnectionMade.call(this);
+    } else
+        this.emit('__hs', {
+            id: this.config.id,
+            path: this.config.path || this.config.socketRoot + this.config.appspace + this.config.id
+        });
+    }
 }
 
 module.exports=Client;

--- a/dao/client.js
+++ b/dao/client.js
@@ -247,12 +247,11 @@ function onConnectionMade(){
 function onHandshake(status) {
     if (status.complete)
         onConnectionMade.call(this);
-    } else
+    else
         this.emit('__hs', {
             id: this.config.id,
             path: this.config.path || this.config.socketRoot + this.config.appspace + this.config.id
         });
-    }
 }
 
 module.exports=Client;

--- a/dao/client.js
+++ b/dao/client.js
@@ -73,7 +73,7 @@ function connect(){
         return;
     }
 
-    if (client.socket !== false) {
+    if (client.socket && client.socket.writable) {
         client.log('Connection already set');
         return;
     }

--- a/dao/client.js
+++ b/dao/client.js
@@ -218,6 +218,16 @@ function connect(){
                 let message=new Message;
                 message.load(events[i]);
 
+                if (message.type === '__identify') {
+                    client.emit('__identify', {
+                        id: client.config.id,
+
+                        // TODO: This can't be right....
+                        path: client.config.socketRoot + client.config.appspace + client.config.id
+                    });
+                    continue;
+                }
+
                 client.log('detected event', message.type, message.data);
                 client.publish(
                    message.type,

--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -277,7 +277,7 @@ function doHandshake(socket) {
         let
             id = clientDetails.id,
             path = clientDetails.path,
-            clientConfig = Object.assign(this.config, {id: id, path: path});
+            clientConfig = Object.assign({}, this.config, {id: id, path: path});
 
         // Add Client to server.of
         this.of[id] = new Client(clientConfig, this.log, socket);

--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const net = require('net'),
-    tls = require('tls'),
-    fs = require('fs'),
-    dgram = require('dgram'),
+const
+    net         = require('net'),
+    tls         = require('tls'),
+    fs          = require('fs'),
+    dgram       = require('dgram'),
     eventParser = require('./eventParser.js'),
-    Message = require('js-message');
+    Message     = require('js-message'),
+    Client      = require('../dao/client');
 
 let Events = require('event-pubsub/es5');
 if(process.version[1]>4){
@@ -27,7 +29,8 @@ class Server extends Events{
                 server          : false,
                 sockets         : [],
                 emit            : emit,
-                broadcast       : broadcast
+                broadcast       : broadcast,
+                of              : {}
             }
         );
 
@@ -243,14 +246,71 @@ function serverCreated(socket) {
         }.bind(this)
     );
 
-    this.publish(
-        'connect',
-        socket
-    );
+    if (this.config.requiresHandshake) {
+        doHandshake.call(this, socket);
+    } else {
+        this.publish(
+            'connect',
+            socket
+        );
+    }
 
     if(this.config.rawBuffer){
         return;
     }
+}
+
+function doHandshake(socket) {
+
+    let t, cb;
+
+    // Callback function
+    cb = (clientDetails, clientSocket) => {
+
+        // Continue only if sockets match
+        if (clientSocket !== socket)
+            return;
+
+        this.off('__hs', cb);
+        clearTimeout(t);
+
+        let
+            id = clientDetails.id,
+            path = clientDetails.path,
+            clientConfig = Object.assign(this.config, {id: id, path: path});
+
+        // Add Client to server.of
+        this.of[id] = new Client(clientConfig, this.log, socket);
+        this.of[id].id = id;
+        this.of[id].path = path;
+        this.of[id].port = this.config.port;
+
+        this.of[id].on('disconnect', function() {
+            delete this.of[id];
+        });
+
+        this.emit(socket, '__hs', {
+            complete: true
+        });
+
+        // Publish connect event
+        this.publish('connect', socket);
+    };
+
+    // Listen for identification
+    this.on('__hs', cb);
+
+    // Ask for identification
+    this.emit(socket, '__hs', {
+        complete: false
+    });
+
+    // Handshake timeout
+    // TODO: Only if emit didn't trigger an error, otherwise you get 2 errors (1 emit, 1 handshake timout later)
+    t = setTimeout(() => {
+        this.off('__hs', cb);
+        this.publish('error', 'Child connection did not finish handshake in time');
+    }, this.config.handshakeTimeout);
 }
 
 function startServer() {

--- a/entities/Defaults.js
+++ b/entities/Defaults.js
@@ -108,6 +108,16 @@ class Defaults{
                     enumerable:true,
                     writable:true,
                     value:false
+                },
+                requiresHandshake   : {
+                    enumerable:true,
+                    writable:true,
+                    value:false
+                },
+                handshakeTimeout    : {
+                    enumerable:true,
+                    writable:true,
+                    value:2000
                 }
             }
         );


### PR DESCRIPTION
@RIAEvangelist 

Rebasing the previous pull-request https://github.com/RIAEvangelist/node-ipc/pull/96 https://github.com/RIAEvangelist/node-ipc/issues/92 on the v8.x branch didn't really work quite well :\ 
So for my own mental sake I created a new pull request, sorry for that.

Anyway, I updated the code and added a second part to the handshake. Making both server and client wait for emitting 'connect' until handshake is done on both ends.

Cause whenever someone connects and sends something really fast after it, there is a small possibility the handshake hasn't arrived yet, and so the server has not yet set the server.of.clientId... So just to be error free...

Let me know, thanks

After I fix the tests..