### PR TITLE
call startTLSServer in socketServer to init this.server

### DIFF
--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -266,7 +266,7 @@ function startServer() {
                 serverCreated.bind(this)
             );
         }else{
-            startTLSServer.bind(this);
+            startTLSServer.bind(this)();
         }
     }else{
         this.server=dgram.createSocket(


### PR DESCRIPTION
### Issue
TLS IPC servers (those configured with a tls option and non-UDP) result in an uncaught on start, since the current control flow in `startServer` leads to an uncalled `startTLSServer` function. Without this function called,  `this.server` isn't initialized, causing an invalid reference to `this.server` on line 284 of `dao/socketServer.js`.

### Solution
Requires calling the bound `startTLSServer` function on line 269 of `startServer`.