### PR TITLE
Fix ipcBuffer being shared with all connected sockets

### DIFF
--- a/dao/socketServer.js
+++ b/dao/socketServer.js
@@ -165,18 +165,18 @@ function gotData(socket,data,UDPSocket){
         return;
     }
 
-    if(!this.ipcBuffer){
-        this.ipcBuffer='';
+    if(!sock.ipcBuffer){
+        sock.ipcBuffer='';
     }
 
-    data=(this.ipcBuffer+=data);
+    data=(sock.ipcBuffer+=data);
 
     if(data.slice(-1)!=eventParser.delimiter || data.indexOf(eventParser.delimiter) == -1){
         this.log('Messages are large, You may want to consider smaller messages.');
         return;
     }
 
-    this.ipcBuffer='';
+    sock.ipcBuffer='';
 
     data=eventParser.parse(data);
 


### PR DESCRIPTION
The ipcBuffer is used to merge the large data sent by the client.
However, this completely fails when there are multiple clients connected to the server, since the ipcBuffer is shared with all connected sockets.

This simple commit fixes this problem by isolating ipcBuffer between sockets.