### PR TITLE
Use Array.from to convert arguments to array instead of spread operator

### DIFF
--- a/services/IPC.js
+++ b/services/IPC.js
@@ -61,7 +61,8 @@ class IPC{
     }
 }
 
-function log(...args){
+function log(){
+    let args = Array.from(arguments);
     if(this.config.silent){
         return;
     }


### PR DESCRIPTION
The package.json lists compatibility with Node.js versions >= v4.0.0; however, the use of the spread operator/rest parameter syntax prevents it from actually running on v4 unless you're using the `--harmony` flag.  This pull replaces the rest parameter syntax with `Array.from()` to convert `arguments` to an array, which seems to enable normal operation without the `--harmony` flag.