### PR TITLE
Fix empty strings interpreted as undefined

### DIFF
--- a/entities/EventParser.js
+++ b/entities/EventParser.js
@@ -11,7 +11,7 @@ class Parser{
   }
 
   format(message){
-    if(!message.data && message.data!==false && message.data!==0){
+    if(!message.data && message.data!==false && message.data!==0 && message.data!==''){
         message.data={};
     }
     if(message.data['_maxListeners']){


### PR DESCRIPTION
Sending empty strings leads to an empty object being send instead. This PR fixes this, so an empty string may be send as empty string.