### PR TITLE
fix (client retry) check if explicitly disconnected

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -188,6 +188,9 @@ function connect(){
 
             setTimeout(
                 function retryTimeout(){
+                    if (client.explicitlyDisconnected) {
+                        return;
+                    }
                     client.retriesRemaining--;
                     client.connect();
                 }.bind(null,client),


### PR DESCRIPTION
Hi Brandon,

we should check if the client was explicitly disconnected during the retry is scheduled, otherwise the new socket is created and the client connects again.

We check right now only on [close event](https://github.com/RIAEvangelist/node-ipc/blob/c82afb34b504e1ff9204c01d457ba645aa7935da/dao/client.js#L169), but we can disconnect client between this `close` event and [reconnecting timeout](https://github.com/RIAEvangelist/node-ipc/blob/c82afb34b504e1ff9204c01d457ba645aa7935da/dao/client.js#L189)