### PR TITLE
Update event-pubsub to v5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ipc",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "A nodejs module for local and remote Inter Process Communication (IPC), Neural Networking, and able to facilitate machine learning.",
   "type": "module",
   "main": "node-ipc.cjs",
@@ -16,7 +16,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "event-pubsub": "5.0.3",
+    "event-pubsub": "5.0.4",
     "js-message": "1.0.7",
     "js-queue": "2.0.2",
     "strong-type": "^1.0.1"


### PR DESCRIPTION
Hi @RIAEvangelist 

Update event-pubsub to fix the security warnings from copyfiles dev dependency
Can you please update the dependency and publish a new version to resolve the deprecation warning.

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
```

Blocked By: https://github.com/RIAEvangelist/event-pubsub/issues/28



